### PR TITLE
build: enable turbopack for build and start scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
-    "start": "next start",
+    "build": "next build --turbopack",
+    "start": "next start --turbopack",
     "lint": "next lint"
   },
   "dependencies": {


### PR DESCRIPTION
Enable Turbopack for build and start scripts. More speed and performance improvements.